### PR TITLE
Fix #6: Tidy up html

### DIFF
--- a/.tidyrc
+++ b/.tidyrc
@@ -1,0 +1,6 @@
+indent: auto
+indent-attributes: yes
+wrap: 80
+tidy-mark: no
+literal-attributes: yes
+new-pre-tags: displayed-eqn

--- a/audio-eq-cookbook.html
+++ b/audio-eq-cookbook.html
@@ -69,11 +69,13 @@
     bandwidth is compressed when mapped from analog to digital using the BLT).</p>
     <p>First, given a biquad transfer function defined as:</p>
 
+<displayed-eqn>
     $$
       \begin{equation}
         H(z) = \frac{b_0 + b_1z^{-1}+b_2z^{-2}}{a_0 + a_1z^{-1}+a_2z^{-2}}
       \end{equation}
     $$
+</displayed-eqn>
     
     <p>This shows 6 coefficients instead of 5 so, depending on your architecture,
     you will likely normalize 
@@ -85,21 +87,27 @@
     to 1 (and collect that into an overall gain coefficient).  Then your transfer function would
     look like:</p>
     
+<displayed-eqn>
       $$
       \begin{equation}
         H(z) = \frac{\left(\displaystyle\frac{b_0}{a_0}\right) + \left(\displaystyle\frac{b_1}{a_0}\right)z^{-1}+\left(\displaystyle\frac{b_2}{a_0}\right)z^{-2}}{1 + \left(\displaystyle\frac{a_1}{a_0}\right)z^{-1}+\left(\displaystyle\frac{a_2}{a_0}\right)z^{-2}}
         \label{direct-form-1}
       \end{equation}
       $$
+</displayed-eqn>
+
  
     <p>or:</p>
 
+<displayed-eqn>
       $$
       \begin{equation}
         H(z) = \left(\frac{b_0}{a_0}\right) \frac{1 + \left(\displaystyle\frac{b_1}{b_0}\right)z^{-1}+\left(\displaystyle\frac{b_2}{b_0}\right)z^{-2}}{1 + \left(\displaystyle\frac{a_1}{a_0}\right)z^{-1}+\left(\displaystyle\frac{a_2}{a_0}\right)z^{-2}}
       \end{equation}
       $$
+</displayed-eqn>
     <p>The most straight forward implementation would be the "Direct Form 1" (\(eq. \ref{direct-form-1}\)):</p>
+<displayed-eqn>
       $$
       \begin{align}
       y[n] = \left(\frac{b_0}{a_0}\right)x[n] & +
@@ -108,6 +116,7 @@
       &-\left(\frac{a_1}{a_0}\right)y[n-1] - \left(\frac{a_2}{a_0}\right)y[n-2]
       \end{align}
       $$
+</displayed-eqn>
     
     <p>This is probably both the best and the easiest method to implement in the
     56K and other fixed-point or floating-point architectures with a double
@@ -154,30 +163,37 @@
     <p>Then compute a few intermediate variables:</p>
     <ol>
       <li>
+<displayed-eqn>
           $$
             \begin{align*}
               A &= \sqrt{10^{\mathrm{dBgain}/20}} & \\
                 & = 10^{\mathrm{dBgain}/40} & \textrm{(for peaking and shelving EQ filters only)}
             \end{align*}
           $$
+</displayed-eqn>
       </li>
       
       <li>
+<displayed-eqn>
           $$
           \omega_0 = 2 \pi \frac{f_0}{F_s}
           $$
+</displayed-eqn>
       </li>
       
       <li>
+<displayed-eqn>
           $$
             \begin{align*}
               & \cos \omega_0 \\
               & \sin \omega_0
             \end{align*}
           $$
+</displayed-eqn>
       </li>
       
       <li>
+<displayed-eqn>
           $$
             \begin{align*}
               \alpha &= \frac{\sin \omega_0}{2 Q} & \textrm{(case: Q)} \\
@@ -188,6 +204,7 @@
                      \frac{1}{A}\right) \left(\frac{1}{S} - 1\right) + 2} & \textrm{(case: S)}
             \end{align*}
           $$
+</displayed-eqn>
       </li>
     </ol>
 
@@ -195,30 +212,36 @@
     <p>FYI: The relationship between bandwidth and Q is</p>
 
     <p class="label">digital filter with BLT</p>
+<displayed-eqn>
       $$
         \frac{1}{Q} = 2\sinh\left(\frac{\log 2}{2} \cdot \mathrm{BW} \cdot
         \frac{\omega_0}{\sin \omega_0}\right)
       $$
+</displayed-eqn>
 
     <p>or</p> 
     
     <p class="label">analog filter prototype</p>
+<displayed-eqn>
       $$
         \frac{1}{Q} = 2 \sinh\left(\frac{\log 2}{2} \cdot \mathrm{BW}\right)
       $$
+</displayed-eqn>
 
         
     <p>The relationship between shelf slope and Q is</p>
+<displayed-eqn>
       $$
         \frac{1}{Q} = \sqrt{\left(A + \frac{1}{A}\right) \left(\frac{1}{S} -
         1\right) + 2}
       $$
-
-
+</displayed-eqn>
+<displayed-eqn>
       $$
         2\sqrt{A}\,\alpha = (\sin \omega_0)\, \sqrt{\left(A^2 +
         1\right)\left(\frac{1}{S}-1\right) + 2A}
       $$
+</displayed-eqn>
 
     <p>is a handy intermediate variable for shelving EQ filters.</p>
     
@@ -228,9 +251,12 @@
     <dl>
       <dt>LPF</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = \frac{1}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b_0 &= \frac{1-\cos\omega_0}{2} \\
@@ -240,15 +266,19 @@
               a_1 &= -2\cos\omega_0 \\
               a_2 &= 1 - \alpha
             \end{align*}
+</displayed-eqn>
           $$
 
       </dd>
       
       <dt>HPF</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = \frac{s^2}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b_0 &=  \frac{1 + \cos \omega_0}{2} \\
@@ -259,14 +289,18 @@
               a_2 &=   1 - \alpha
             \end{align*}
           $$
+</displayed-eqn>
 
       </dd>
       
       <dt>BPF <br>(constant skirt gain, <br>peak gain = Q)</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = \frac{s}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b0 &=   \frac{\sin\omega_0}{2}  =   Q \alpha \\
@@ -277,14 +311,18 @@
               a2 &=   1 - \alpha
             \end{align*}
           $$
+</displayed-eqn>
 
       </dd>
       
       <dt>BPF <br>(constant 0 dB peak gain)</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = \frac{\displaystyle\frac{s}{Q}}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b_0 &=   \alpha \\
@@ -295,14 +333,18 @@
               a_2 &=   1 - \alpha
             \end{align*}
           $$
+</displayed-eqn>
 
       </dd>
       
       <dt>notch</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = \frac{s^2 + 1}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b_0 &=   1 \\
@@ -313,14 +355,18 @@
               a_2 &=   1 - \alpha
             \end{align*}
           $$
+</displayed-eqn>
 
       </dd>
       
       <dt>APF</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = \frac{s^2 - \displaystyle\frac{s}{Q} + 1}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b_0 &=   1 - \alpha \\
@@ -331,14 +377,18 @@
               a_2 &=   1 - \alpha
             \end{align*}
           $$
+</displayed-eqn>
 
       </dd>
       
       <dt>peakingEQ</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = \frac{s^2 + s\displaystyle\frac{A}{Q} + 1}{s^2 + \displaystyle\frac{s}{AQ} + 1}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b_0 &=   1 + \alpha A \\
@@ -349,14 +399,18 @@
               a_2 &=   1 - \frac{\alpha}{A}
             \end{align*}
           $$
+</displayed-eqn>
       </dd>
       
       <dt>lowShelf</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = A \frac{s^2 + \displaystyle\frac{\sqrt{A}}{Q} s + A}
                           {A*s^2 + \displaystyle\frac{\sqrt{A}}{Q} s + 1}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b_0 &=    A\left( (A+1) - (A-1)\cos\omega_0 + 2\sqrt{A}\, \alpha \right) \\
@@ -367,15 +421,19 @@
               a_2 &=        (A+1) + (A-1)\cos\omega_0 - 2\sqrt{A}\, \alpha
             \end{align*}
           $$
+</displayed-eqn>
 
       </dd>
       
       <dt>highShelf</dt>
       <dd>
+<displayed-eqn>
           $$
             H(s) = A \frac{As^2 + \displaystyle\frac{\sqrt{A}}{Q}s + 1}
                    {s^2 + \displaystyle\frac{\sqrt{A}}{Q} s + A}
           $$
+</displayed-eqn>
+<displayed-eqn>
           $$
             \begin{align*}
               b_0 &=    A\left( (A+1) + (A-1)\cos\omega_0 + 2\sqrt{A}\alpha \right) \\
@@ -386,6 +444,7 @@
               a_2 &=        (A+1) - (A-1)\cos\omega_0 - 2\sqrt{A}\alpha
             \end{align*}
           $$
+</displayed-eqn>
 
       </dd>
       
@@ -394,24 +453,30 @@
     <p>FYI: The bilinear transform (with compensation for frequency warping) substitutes:</p>
 
     <p class="label">(normalized)</p>
+<displayed-eqn>
       $$
         s \leftarrow \frac{1}{\tan\displaystyle\frac{\omega_0}{2}} \frac{1-z^{-1}}{1+z^{-1}}
       $$
+</displayed-eqn>
 
     
     <p>and makes use of these trig identities:</p>
     <ol>
       <li>
+<displayed-eqn>
           $$
             \tan\frac{\omega_0}{2} = \frac{\sin\omega_0}{1+\cos\omega_0}
           $$
+</displayed-eqn>
 
       </li>
       
       <li>
+<displayed-eqn>
           $$
             \left(\tan\frac{\omega_0}{2}\right)^2 = \frac{1-\cos\omega_0}{1+\cos\omega_0}
           $$
+</displayed-eqn>
 
       </li>
     </ol>
@@ -419,13 +484,16 @@
     <p>resulting in these substitutions:</p>
     <ol>
       <li>
+<displayed-eqn>
           $$
             1 \leftarrow \frac{1+\cos\omega_0}{1+\cos\omega_0}\frac{1+2z^{-1}+z^{-2}}{1+2z^{-1}+z^{-2}}
           $$
+</displayed-eqn>
 
       </li>
       
       <li>
+<displayed-eqn>
           $$
             \begin{align*}
               s \leftarrow & \frac{1+\cos\omega_0}{\sin\omega_0}
@@ -433,13 +501,16 @@
                 & = \frac{1+\cos\omega_0}{\sin\omega_0} \frac{1-z^{-2}}{1+2z^{-1}+z^{-2}}
             \end{align*}
           $$
+</displayed-eqn>
 
       </li>
       
       <li>
+<displayed-eqn>
           $$
             s^2 \leftarrow \frac{1+\cos\omega_0}{1-\cos\omega_0} \frac{1-2z^{-1}+z^{-2}}{1+2z^{-1}+z^{-2}}
           $$
+</displayed-eqn>
 
       </li>
     </ol>
@@ -451,68 +522,86 @@
 
     <p>The factor:</p>
 
+<displayed-eqn>
       $$
         \frac{1+\cos\omega_0}{1+2z^{-1}+z^{-2}}
       $$
+</displayed-eqn>
 
 
     <p>is common to all terms in both numerator and denominator, can be factored
     out, and thus be left out in the substitutions above resulting in:</p>
     <ol>
       <li>
+<displayed-eqn>
           $$
             1 \leftarrow \frac{1+2z^{-1}+z^{-2}}{1+\cos\omega_0}
           $$
+</displayed-eqn>
 
       </li>
       
       <li>
+<displayed-eqn>
           $$
             s \leftarrow \frac{1-z^{-2}}{\sin\omega_0}
           $$
+</displayed-eqn>
 
       </li>
       
       <li>
+<displayed-eqn>
           $$
             s^2 = \frac{1-2z^{-1}+z^{-2}}{1-\cos\omega_0}
           $$
+</displayed-eqn>
 
       </li>
     </ol>
     
     <p>In addition, all terms, numerator and denominator, can be multiplied by a
     common
+<displayed-eqn>
         $$
           \sin^2\omega_0
         $$
+</displayed-eqn>
 	factor, finally resulting in these substitutions:<p>
     <ol>
       <li>
+<displayed-eqn>
               $$
                 1 \leftarrow (1 + 2z^{-1} + z^{-2}) (1 - \cos\omega_0)
               $$
+</displayed-eqn>
 
       </li>
 
       <li>
+<displayed-eqn>
               $$
                 s \leftarrow (1-z^{-2})\sin\omega_0
               $$
+</displayed-eqn>
 
       </li>
 
       <li>
+<displayed-eqn>
               $$
                 s^2 = (1 - 2z^{-1} + z^{-2}) (1 + \cos\omega_0)
               $$
+</displayed-eqn>
 
       </li>
 
       <li>
+<displayed-eqn>
               $$
               1 + s^2 = 2\, (1 - 2\cos\omega_0\,z^{-1} + z^{-2})
               $$
+</displayed-eqn>
 
       </li>
     </ol>

--- a/audio-eq-cookbook.html
+++ b/audio-eq-cookbook.html
@@ -1,17 +1,16 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="utf-8">
-	<title>Cookbook formulae for audio EQ biquad filter coefficients</title>
-      <script>
-        MathJax = {
-          tex: {
-            tags: 'ams'
-          }
-        };
-      </script>
-	<script 
-    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+  <meta charset="utf-8">
+  <title>Cookbook formulae for audio EQ biquad filter coefficients</title>
+  <script>
+   MathJax = {
+     tex: {
+       tags: 'ams'
+     }
+   };
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
   </script>
   <style media="screen">
     body {
@@ -26,164 +25,144 @@
     }
     
     dl {
-    	margin: 2em 0;
-    	padding: 0;
-    	font-family: georgia, times, serif;
+        margin: 2em 0;
+        padding: 0;
+        font-family: georgia, times, serif;
     }
     
     dt {
-    	position: relative;
-    	left: 0;
-    	top: 1.1em;
-    	width: 10em;
-    	font-weight: bold;
+        position: relative;
+        left: 0;
+        top: 1.1em;
+        width: 10em;
+        font-weight: bold;
     }
 
     dd {
-    	border-left: 1px solid gray;
-    	margin: 0 0 0 11em;
-    	padding: 0 0 .5em .5em;
+        border-left: 1px solid gray;
+        margin: 0 0 0 11em;
+        padding: 0 0 .5em .5em;
     }
-  
+
   </style>
 </head>
 <body>
   <h1>Cookbook formulae for audio equalizer biquad filter coefficients</h1>
   <dl>
     <dt>Author</dt>
-    <dd><a href="mailto:rbj@audioimagination.com">Robert Bristow-Johnson</a></dd>
-    
+    <dd>
+      <a href="mailto:rbj@audioimagination.com">Robert Bristow-Johnson</a>
+    </dd>
     <dt>Editor</dt>
-    <dd><a href="mailto:schepers@w3.org">Doug Schepers (W3C)</a></dd>
+    <dd>
+      <a href="mailto:schepers@w3.org">Doug Schepers (W3C)</a>
+    </dd>
   </dl>
-  <p>Adapted from <a
-  href="https://webaudio.github.io/Audio-EQ-Cookbook/Audio-EQ-Cookbook.txt">Audio-EQ-Cookbook.txt</a>, by Robert Bristow, with permission.</p>  
-  
+  <p>Adapted from <a href=
+  "https://webaudio.github.io/Audio-EQ-Cookbook/Audio-EQ-Cookbook.txt">Audio-EQ-Cookbook.txt</a>,
+  by Robert Bristow, with permission.</p>
   <section>
-      <h2>Biquad Filter Formulae</h2>
+    <h2>Biquad Filter Formulae</h2>
     <p>All filter transfer functions were derived from analog prototypes (that
-    are shown below for each equalizer (EQ) filter type) and had been digitized using the
-    Bilinear Transform (BLT).  BLT frequency warping has been taken into account for
-    both significant frequency relocation (this is the normal "prewarping" that
-    is necessary when using the BLT) and for bandwidth readjustment (since the
-    bandwidth is compressed when mapped from analog to digital using the BLT).</p>
+    are shown below for each equalizer (EQ) filter type) and had been digitized
+    using the Bilinear Transform (BLT). BLT frequency warping has been taken
+    into account for both significant frequency relocation (this is the normal
+    "prewarping" that is necessary when using the BLT) and for bandwidth
+    readjustment (since the bandwidth is compressed when mapped from analog to
+    digital using the BLT).</p>
     <p>First, given a biquad transfer function defined as:</p>
-
-<displayed-eqn>
-    $$
+    <!-- displayed-eqn is just a random tag to keep html tidy from indenting the
+contents which could mangle the equations.  It's not used for anything else, and
+it's not a custom element.
+-->
+    <displayed-eqn>   $$
       \begin{equation}
         H(z) = \frac{b_0 + b_1z^{-1}+b_2z^{-2}}{a_0 + a_1z^{-1}+a_2z^{-2}}
       \end{equation}
     $$
 </displayed-eqn>
-    
-    <p>This shows 6 coefficients instead of 5 so, depending on your architecture,
-    you will likely normalize 
-        \(
-        a_0
-	\)
-    to be 1 and perhaps also 
-        \(b_0\)
-    to 1 (and collect that into an overall gain coefficient).  Then your transfer function would
-    look like:</p>
-    
-<displayed-eqn>
-      $$
+    <p>This shows 6 coefficients instead of 5 so, depending on your
+    architecture, you will likely normalize \( a_0 \) to be 1 and perhaps also
+    \(b_0\) to 1 (and collect that into an overall gain coefficient). Then your
+    transfer function would look like:</p>
+    <displayed-eqn>     $$
       \begin{equation}
         H(z) = \frac{\left(\displaystyle\frac{b_0}{a_0}\right) + \left(\displaystyle\frac{b_1}{a_0}\right)z^{-1}+\left(\displaystyle\frac{b_2}{a_0}\right)z^{-2}}{1 + \left(\displaystyle\frac{a_1}{a_0}\right)z^{-1}+\left(\displaystyle\frac{a_2}{a_0}\right)z^{-2}}
         \label{direct-form-1}
       \end{equation}
       $$
 </displayed-eqn>
-
- 
     <p>or:</p>
-
-<displayed-eqn>
-      $$
+    <displayed-eqn>     $$
       \begin{equation}
         H(z) = \left(\frac{b_0}{a_0}\right) \frac{1 + \left(\displaystyle\frac{b_1}{b_0}\right)z^{-1}+\left(\displaystyle\frac{b_2}{b_0}\right)z^{-2}}{1 + \left(\displaystyle\frac{a_1}{a_0}\right)z^{-1}+\left(\displaystyle\frac{a_2}{a_0}\right)z^{-2}}
       \end{equation}
       $$
 </displayed-eqn>
-    <p>The most straight forward implementation would be the "Direct Form 1" (\(eq. \ref{direct-form-1}\)):</p>
-<displayed-eqn>
-      $$
+    <p>The most straight forward implementation would be the "Direct Form 1"
+    (\(eq. \ref{direct-form-1}\)):</p>
+    <displayed-eqn>     $$
       \begin{align}
       y[n] = \left(\frac{b_0}{a_0}\right)x[n] & +
       \left(\frac{b_1}{a_0}\right)x[n-1] + \left(\frac{b_2}{a_0}\right)x[n-2]
       \nonumber \\
-      &-\left(\frac{a_1}{a_0}\right)y[n-1] - \left(\frac{a_2}{a_0}\right)y[n-2]
+      &amp;-\left(\frac{a_1}{a_0}\right)y[n-1] - \left(\frac{a_2}{a_0}\right)y[n-2]
       \end{align}
       $$
 </displayed-eqn>
-    
-    <p>This is probably both the best and the easiest method to implement in the
-    56K and other fixed-point or floating-point architectures with a double
+    <p>This is probably both the best and the easiest method to implement in
+    the 56K and other fixed-point or floating-point architectures with a double
     wide accumulator.</p>
-    
     <p>Begin with these user defined parameters:</p>
-    
-    <dl>      
+    <dl>
       <dt>\(F_s\)</dt>
       <dd>the sampling frequency</dd>
-
       <dt>\(f_0\)</dt>
-      <dd>Center Frequency or Corner Frequency, or shelf midpoint frequency, 
-          depending on which filter type.  The "significant frequency".
-          "wherever it's happenin', man."</dd>
-      
+      <dd>Center Frequency or Corner Frequency, or shelf midpoint frequency,
+      depending on which filter type. The "significant frequency". "wherever
+      it's happenin', man."</dd>
       <dt>\(\mathrm{dBgain}\)</dt>
       <dd>used only for peaking and shelving filters</dd>
-      
       <dt>\(Q\) or \(\mathrm{BW}\) or \(S\)</dt>
       <dd>
         <dl>
           <dt>\(Q\)</dt>
           <dd>the EE kind of definition, except for peakingEQ in which A*Q is
-              the classic EE Q.  That adjustment in definition was made so that
-              a boost of N dB followed by a cut of N dB for identical Q and
-              f0/Fs results in a precisely flat unity gain filter or "wire".</dd>
-
+          the classic EE Q. That adjustment in definition was made so that a
+          boost of N dB followed by a cut of N dB for identical Q and f0/Fs
+          results in a precisely flat unity gain filter or "wire".</dd>
           <dt>\(\mathrm{BW}\)</dt>
-          <dd>the bandwidth in octaves (between -3 dB frequencies for BPF
-              and notch or between midpoint (dBgain/2) gain frequencies for
-              peaking EQ)</dd>
-
+          <dd>the bandwidth in octaves (between -3 dB frequencies for BPF and
+          notch or between midpoint (dBgain/2) gain frequencies for peaking
+          EQ)</dd>
           <dt>\(S\)</dt>
-          <dd>a "shelf slope" parameter (for shelving EQ only).  When S = 1,
-              the shelf slope is as steep as it can be and remain monotonically
-              increasing or decreasing gain with frequency.  The shelf slope, in
-              dB/octave, remains proportional to S for all other values for a
-              fixed f0/Fs and dBgain</dd>
+          <dd>a "shelf slope" parameter (for shelving EQ only). When S = 1, the
+          shelf slope is as steep as it can be and remain monotonically
+          increasing or decreasing gain with frequency. The shelf slope, in
+          dB/octave, remains proportional to S for all other values for a fixed
+          f0/Fs and dBgain</dd>
         </dl>
-      </dd>      
+      </dd>
     </dl>
-    
     <p>Then compute a few intermediate variables:</p>
     <ol>
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              A &= \sqrt{10^{\mathrm{dBgain}/20}} & \\
+              A &amp;= \sqrt{10^{\mathrm{dBgain}/20}} & \\
                 & = 10^{\mathrm{dBgain}/40} & \textrm{(for peaking and shelving EQ filters only)}
             \end{align*}
           $$
 </displayed-eqn>
       </li>
-      
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
           \omega_0 = 2 \pi \frac{f_0}{F_s}
           $$
 </displayed-eqn>
       </li>
-      
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
               & \cos \omega_0 \\
               & \sin \omega_0
@@ -191,310 +170,250 @@
           $$
 </displayed-eqn>
       </li>
-      
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              \alpha &= \frac{\sin \omega_0}{2 Q} & \textrm{(case: Q)} \\
-                     &= \sin \omega_0 \, \sinh\left(\frac{\log 2}{2} \cdot
+              \alpha &amp;= \frac{\sin \omega_0}{2 Q} & \textrm{(case: Q)} \\
+                     &amp;= \sin \omega_0 \, \sinh\left(\frac{\log 2}{2} \cdot
                      \mathrm{BW} \cdot 
                      \frac{\omega_0}{\sin \omega_0}\right) & \textrm{(case: BW)} \\
-                     &= \frac{\sin \omega_0}{2} \sqrt{\left(A +
+                     &amp;= \frac{\sin \omega_0}{2} \sqrt{\left(A +
                      \frac{1}{A}\right) \left(\frac{1}{S} - 1\right) + 2} & \textrm{(case: S)}
             \end{align*}
           $$
 </displayed-eqn>
       </li>
     </ol>
-
-
     <p>FYI: The relationship between bandwidth and Q is</p>
-
     <p class="label">digital filter with BLT</p>
-<displayed-eqn>
-      $$
+    <displayed-eqn>     $$
         \frac{1}{Q} = 2\sinh\left(\frac{\log 2}{2} \cdot \mathrm{BW} \cdot
         \frac{\omega_0}{\sin \omega_0}\right)
       $$
 </displayed-eqn>
-
-    <p>or</p> 
-    
+    <p>or</p>
     <p class="label">analog filter prototype</p>
-<displayed-eqn>
-      $$
+    <displayed-eqn>     $$
         \frac{1}{Q} = 2 \sinh\left(\frac{\log 2}{2} \cdot \mathrm{BW}\right)
       $$
 </displayed-eqn>
-
-        
     <p>The relationship between shelf slope and Q is</p>
-<displayed-eqn>
-      $$
+    <displayed-eqn>     $$
         \frac{1}{Q} = \sqrt{\left(A + \frac{1}{A}\right) \left(\frac{1}{S} -
         1\right) + 2}
       $$
 </displayed-eqn>
-<displayed-eqn>
-      $$
+    <displayed-eqn>     $$
         2\sqrt{A}\,\alpha = (\sin \omega_0)\, \sqrt{\left(A^2 +
         1\right)\left(\frac{1}{S}-1\right) + 2A}
       $$
 </displayed-eqn>
-
     <p>is a handy intermediate variable for shelving EQ filters.</p>
-    
-    <p>Finally, compute the coefficients for whichever filter type you want:</p>
-    <p>(The analog prototypes, H(s), are shown for each filter type for normalized frequency.)</p>
-    
+    <p>Finally, compute the coefficients for whichever filter type you
+    want:</p>
+    <p>(The analog prototypes, H(s), are shown for each filter type for
+    normalized frequency.)</p>
     <dl>
       <dt>LPF</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = \frac{1}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b_0 &= \frac{1-\cos\omega_0}{2} \\
-              b_1 &= 1-\cos\omega_0 \\
-              b_2 &= \frac{1-\cos\omega_0}{2} \\
-              a_0 &= 1 + \alpha \\
-              a_1 &= -2\cos\omega_0 \\
-              a_2 &= 1 - \alpha
+              b_0 &amp;= \frac{1-\cos\omega_0}{2} \\
+              b_1 &amp;= 1-\cos\omega_0 \\
+              b_2 &amp;= \frac{1-\cos\omega_0}{2} \\
+              a_0 &amp;= 1 + \alpha \\
+              a_1 &amp;= -2\cos\omega_0 \\
+              a_2 &amp;= 1 - \alpha
             \end{align*}
           $$
 </displayed-eqn>
-
       </dd>
-      
       <dt>HPF</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = \frac{s^2}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b_0 &=  \frac{1 + \cos \omega_0}{2} \\
-              b_1 &= -(1 + \cos \omega_0) \\
-              b_2 &=  \frac{1 + \cos \omega_0}{2} \\
-              a_0 &=   1 + \alpha \\
-              a_1 &=  -2\cos \omega_0 \\
-              a_2 &=   1 - \alpha
+              b_0 &amp;=  \frac{1 + \cos \omega_0}{2} \\
+              b_1 &amp;= -(1 + \cos \omega_0) \\
+              b_2 &amp;=  \frac{1 + \cos \omega_0}{2} \\
+              a_0 &amp;=   1 + \alpha \\
+              a_1 &amp;=  -2\cos \omega_0 \\
+              a_2 &amp;=   1 - \alpha
             \end{align*}
           $$
 </displayed-eqn>
-
       </dd>
-      
-      <dt>BPF <br>(constant skirt gain, <br>peak gain = Q)</dt>
+      <dt>BPF<br>
+      (constant skirt gain,<br>
+      peak gain = Q)</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = \frac{s}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b0 &=   \frac{\sin\omega_0}{2}  =   Q \alpha \\
-              b1 &=   0 \\
-              b2 &=  -\frac{\sin\omega_0}{2}  =  -Q \alpha \\
-              a0 &=   1 + \alpha \\
-              a1 &=  -2\cos\omega_0 \\
-              a2 &=   1 - \alpha
+              b0 &amp;=   \frac{\sin\omega_0}{2}  =   Q \alpha \\
+              b1 &amp;=   0 \\
+              b2 &amp;=  -\frac{\sin\omega_0}{2}  =  -Q \alpha \\
+              a0 &amp;=   1 + \alpha \\
+              a1 &amp;=  -2\cos\omega_0 \\
+              a2 &amp;=   1 - \alpha
             \end{align*}
           $$
 </displayed-eqn>
-
       </dd>
-      
-      <dt>BPF <br>(constant 0 dB peak gain)</dt>
+      <dt>BPF<br>
+      (constant 0 dB peak gain)</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = \frac{\displaystyle\frac{s}{Q}}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b_0 &=   \alpha \\
-              b_1 &=   0 \\
-              b_2 &=  -\alpha \\
-              a_0 &=   1 + \alpha \\
-              a_1 &=  -2\cos \omega_0 \\
-              a_2 &=   1 - \alpha
+              b_0 &amp;=   \alpha \\
+              b_1 &amp;=   0 \\
+              b_2 &amp;=  -\alpha \\
+              a_0 &amp;=   1 + \alpha \\
+              a_1 &amp;=  -2\cos \omega_0 \\
+              a_2 &amp;=   1 - \alpha
             \end{align*}
           $$
 </displayed-eqn>
-
       </dd>
-      
       <dt>notch</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = \frac{s^2 + 1}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b_0 &=   1 \\
-              b_1 &=  -2\cos \omega_0 \\
-              b_2 &=   1 \\
-              a_0 &=   1 + \alpha \\
-              a_1 &=  -2\cos \omega_0 \\
-              a_2 &=   1 - \alpha
+              b_0 &amp;=   1 \\
+              b_1 &amp;=  -2\cos \omega_0 \\
+              b_2 &amp;=   1 \\
+              a_0 &amp;=   1 + \alpha \\
+              a_1 &amp;=  -2\cos \omega_0 \\
+              a_2 &amp;=   1 - \alpha
             \end{align*}
           $$
 </displayed-eqn>
-
       </dd>
-      
       <dt>APF</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = \frac{s^2 - \displaystyle\frac{s}{Q} + 1}{s^2 + \displaystyle\frac{s}{Q} + 1}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b_0 &=   1 - \alpha \\
-              b_1 &=  -2\cos\omega_0 \\
-              b_2 &=   1 + \alpha \\
-              a_0 &=   1 + \alpha \\
-              a_1 &=  -2\cos\omega_0 \\
-              a_2 &=   1 - \alpha
+              b_0 &amp;=   1 - \alpha \\
+              b_1 &amp;=  -2\cos\omega_0 \\
+              b_2 &amp;=   1 + \alpha \\
+              a_0 &amp;=   1 + \alpha \\
+              a_1 &amp;=  -2\cos\omega_0 \\
+              a_2 &amp;=   1 - \alpha
             \end{align*}
           $$
 </displayed-eqn>
-
       </dd>
-      
       <dt>peakingEQ</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = \frac{s^2 + s\displaystyle\frac{A}{Q} + 1}{s^2 + \displaystyle\frac{s}{AQ} + 1}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b_0 &=   1 + \alpha A \\
-              b_1 &=  -2\cos\omega_0 \\
-              b_2 &=   1 - \alpha A \\
-              a_0 &=   1 + \frac{\alpha}{A} \\
-              a_1 &=  -2\cos\omega_0 \\
-              a_2 &=   1 - \frac{\alpha}{A}
+              b_0 &amp;=   1 + \alpha A \\
+              b_1 &amp;=  -2\cos\omega_0 \\
+              b_2 &amp;=   1 - \alpha A \\
+              a_0 &amp;=   1 + \frac{\alpha}{A} \\
+              a_1 &amp;=  -2\cos\omega_0 \\
+              a_2 &amp;=   1 - \frac{\alpha}{A}
             \end{align*}
           $$
 </displayed-eqn>
       </dd>
-      
       <dt>lowShelf</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = A \frac{s^2 + \displaystyle\frac{\sqrt{A}}{Q} s + A}
                           {A*s^2 + \displaystyle\frac{\sqrt{A}}{Q} s + 1}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b_0 &=    A\left( (A+1) - (A-1)\cos\omega_0 + 2\sqrt{A}\, \alpha \right) \\
-              b_1 &=  2A\left( (A-1) - (A+1)\cos\omega_0                   \right) \\
-              b_2 &=    A\left( (A+1) - (A-1)\cos\omega_0 - 2\sqrt{A}\, \alpha \right) \\
-              a_0 &=        (A+1) + (A-1)\cos\omega_0 + 2\sqrt{A}\, \alpha \\
-              a_1 &=   -2\left( (A-1) + (A+1)\cos\omega_0                   \right) \\
-              a_2 &=        (A+1) + (A-1)\cos\omega_0 - 2\sqrt{A}\, \alpha
+              b_0 &amp;=    A\left( (A+1) - (A-1)\cos\omega_0 + 2\sqrt{A}\, \alpha \right) \\
+              b_1 &amp;=  2A\left( (A-1) - (A+1)\cos\omega_0                   \right) \\
+              b_2 &amp;=    A\left( (A+1) - (A-1)\cos\omega_0 - 2\sqrt{A}\, \alpha \right) \\
+              a_0 &amp;=        (A+1) + (A-1)\cos\omega_0 + 2\sqrt{A}\, \alpha \\
+              a_1 &amp;=   -2\left( (A-1) + (A+1)\cos\omega_0                   \right) \\
+              a_2 &amp;=        (A+1) + (A-1)\cos\omega_0 - 2\sqrt{A}\, \alpha
             \end{align*}
           $$
 </displayed-eqn>
-
       </dd>
-      
       <dt>highShelf</dt>
       <dd>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             H(s) = A \frac{As^2 + \displaystyle\frac{\sqrt{A}}{Q}s + 1}
                    {s^2 + \displaystyle\frac{\sqrt{A}}{Q} s + A}
           $$
 </displayed-eqn>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
-              b_0 &=    A\left( (A+1) + (A-1)\cos\omega_0 + 2\sqrt{A}\alpha \right) \\
-              b_1 &= -2A\left( (A-1) + (A+1)\cos\omega_0                   \right) \\
-              b_2 &=    A\left( (A+1) + (A-1)\cos\omega_0 - 2\sqrt{A}\alpha \right) \\
-              a_0 &=        (A+1) - (A-1)\cos\omega_0 + 2\sqrt{A}\alpha \\
-              a_1 &=    2\left( (A-1) - (A+1)\cos\omega_0                   \right) \\
-              a_2 &=        (A+1) - (A-1)\cos\omega_0 - 2\sqrt{A}\alpha
+              b_0 &amp;=    A\left( (A+1) + (A-1)\cos\omega_0 + 2\sqrt{A}\alpha \right) \\
+              b_1 &amp;= -2A\left( (A-1) + (A+1)\cos\omega_0                   \right) \\
+              b_2 &amp;=    A\left( (A+1) + (A-1)\cos\omega_0 - 2\sqrt{A}\alpha \right) \\
+              a_0 &amp;=        (A+1) - (A-1)\cos\omega_0 + 2\sqrt{A}\alpha \\
+              a_1 &amp;=    2\left( (A-1) - (A+1)\cos\omega_0                   \right) \\
+              a_2 &amp;=        (A+1) - (A-1)\cos\omega_0 - 2\sqrt{A}\alpha
             \end{align*}
           $$
 </displayed-eqn>
-
       </dd>
-      
     </dl>
-    
-    <p>FYI: The bilinear transform (with compensation for frequency warping) substitutes:</p>
-
+    <p>FYI: The bilinear transform (with compensation for frequency warping)
+    substitutes:</p>
     <p class="label">(normalized)</p>
-<displayed-eqn>
-      $$
+    <displayed-eqn>     $$
         s \leftarrow \frac{1}{\tan\displaystyle\frac{\omega_0}{2}} \frac{1-z^{-1}}{1+z^{-1}}
       $$
 </displayed-eqn>
-
-    
     <p>and makes use of these trig identities:</p>
     <ol>
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \tan\frac{\omega_0}{2} = \frac{\sin\omega_0}{1+\cos\omega_0}
           $$
 </displayed-eqn>
-
       </li>
-      
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \left(\tan\frac{\omega_0}{2}\right)^2 = \frac{1-\cos\omega_0}{1+\cos\omega_0}
           $$
 </displayed-eqn>
-
       </li>
     </ol>
-
     <p>resulting in these substitutions:</p>
     <ol>
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             1 \leftarrow \frac{1+\cos\omega_0}{1+\cos\omega_0}\frac{1+2z^{-1}+z^{-2}}{1+2z^{-1}+z^{-2}}
           $$
 </displayed-eqn>
-
       </li>
-      
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             \begin{align*}
               s \leftarrow & \frac{1+\cos\omega_0}{\sin\omega_0}
               \frac{1-z^{-1}}{1+z^{-1}} \\
@@ -502,124 +421,92 @@
             \end{align*}
           $$
 </displayed-eqn>
-
       </li>
-      
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             s^2 \leftarrow \frac{1+\cos\omega_0}{1-\cos\omega_0} \frac{1-2z^{-1}+z^{-2}}{1+2z^{-1}+z^{-2}}
           $$
 </displayed-eqn>
-
       </li>
     </ol>
-    
-
-    
-
-    
-
     <p>The factor:</p>
-
-<displayed-eqn>
-      $$
+    <displayed-eqn>     $$
         \frac{1+\cos\omega_0}{1+2z^{-1}+z^{-2}}
       $$
 </displayed-eqn>
-
-
-    <p>is common to all terms in both numerator and denominator, can be factored
-    out, and thus be left out in the substitutions above resulting in:</p>
+    <p>is common to all terms in both numerator and denominator, can be
+    factored out, and thus be left out in the substitutions above resulting
+    in:</p>
     <ol>
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             1 \leftarrow \frac{1+2z^{-1}+z^{-2}}{1+\cos\omega_0}
           $$
 </displayed-eqn>
-
       </li>
-      
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             s \leftarrow \frac{1-z^{-2}}{\sin\omega_0}
           $$
 </displayed-eqn>
-
       </li>
-      
       <li>
-<displayed-eqn>
-          $$
+        <displayed-eqn>         $$
             s^2 \leftarrow \frac{1-2z^{-1}+z^{-2}}{1-\cos\omega_0}
           $$
 </displayed-eqn>
-
       </li>
     </ol>
-    
-    <p>In addition, all terms, numerator and denominator, can be multiplied by a
-    common
-<displayed-eqn>
-        $$
+    <p>In addition, all terms, numerator and denominator, can be multiplied by
+    a common</p>
+    <displayed-eqn>       $$
           \sin^2\omega_0
         $$
-</displayed-eqn>
-	factor, finally resulting in these substitutions:<p>
+</displayed-eqn>factor, finally resulting in these substitutions:
     <ol>
       <li>
-<displayed-eqn>
-              $$
+        <displayed-eqn>             $$
                 1 \leftarrow (1 + 2z^{-1} + z^{-2}) (1 - \cos\omega_0)
               $$
 </displayed-eqn>
-
       </li>
-
       <li>
-<displayed-eqn>
-              $$
+        <displayed-eqn>             $$
                 s \leftarrow (1-z^{-2})\sin\omega_0
               $$
 </displayed-eqn>
-
       </li>
-
       <li>
-<displayed-eqn>
-              $$
+        <displayed-eqn>             $$
                 s^2 \leftarrow (1 - 2z^{-1} + z^{-2}) (1 + \cos\omega_0)
               $$
 </displayed-eqn>
-
       </li>
-
       <li>
-<displayed-eqn>
-              $$
+        <displayed-eqn>             $$
               1 + s^2 \leftarrow 2\, (1 - 2\cos\omega_0\,z^{-1} + z^{-2})
               $$
 </displayed-eqn>
-
       </li>
     </ol>
-    
-    <p>The biquad coefficient formulae above come out after a little simplification.</p>
-    
+    <p>The biquad coefficient formulae above come out after a little
+    simplification.</p>
   </section>
-
   <section id="acknowledgements">
     <h2>Acknowledgements</h2>
-    <p>Special thanks to <a href="mailto:rbj@audioimagination.com">Robert Bristow-Johnson</a> for creating the  Audio EQ Cookbook and permitting its adaption and use for the Web Audio API.<p>
-    <p>Thanks to <a href="mailto:peter.krautzberger@mathjax.org">Peter Krautzberger</a> for help in adapting these mathematical formulae to MathML, and to the whole <a href="https://www.mathjax.org/">MathJax</a> team for making the JavaScript extension that makes the use of math on the web possible.</p>
-    <p>Thanks to Peter Jipsen, creator of <a href="http://www1.chapman.edu/~jipsen/mathml/asciimath.html">ASCIIMathML</a>, for making it easier to convert ASCII math notation to MathML.
-    
-     <p>
-       Converted to using TeX formulas instead of MathML by <a href="mailto:rtoy@chromium.org">Raymond Toy</a>.
-     </p>
+    <p>Special thanks to <a href="mailto:rbj@audioimagination.com">Robert
+    Bristow-Johnson</a> for creating the Audio EQ Cookbook and permitting its
+    adaption and use for the Web Audio API.</p>
+    <p>Thanks to <a href="mailto:peter.krautzberger@mathjax.org">Peter
+    Krautzberger</a> for help in adapting these mathematical formulae to
+    MathML, and to the whole <a href="https://www.mathjax.org/">MathJax</a>
+    team for making the JavaScript extension that makes the use of math on the
+    web possible.</p>
+    <p>Thanks to Peter Jipsen, creator of <a href=
+    "http://www1.chapman.edu/~jipsen/mathml/asciimath.html">ASCIIMathML</a>,
+    for making it easier to convert ASCII math notation to MathML.</p>
+    <p>Converted to using TeX formulas instead of MathML by <a href=
+    "mailto:rtoy@chromium.org">Raymond Toy</a>.</p>
   </section>
-  
 </body>
 </html>

--- a/audio-eq-cookbook.html
+++ b/audio-eq-cookbook.html
@@ -266,8 +266,8 @@
               a_1 &= -2\cos\omega_0 \\
               a_2 &= 1 - \alpha
             \end{align*}
-</displayed-eqn>
           $$
+</displayed-eqn>
 
       </dd>
       


### PR DESCRIPTION
Run html tidy over the file.

To get this to work right, use a custom config (in .tidyrc).  And also need to wrap all the displayed equations in a new tag `<displayed-eqn>`.  This tag is not a custom element.  It's just to tell tidy not to format the contents (as if it were a `<pre>` block).  

Tidy doesn't do a great job the the new tag (but it does the same thing for `<pre>`), but the rest of the file is nicely indented and wrapped to 80 col.